### PR TITLE
Add initial design doc

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD030": false,
+  "MD013": false
+}

--- a/docs/01-design-doc.md
+++ b/docs/01-design-doc.md
@@ -3,7 +3,8 @@
 ## Context and Scope
 
 The [newsletters round up page][] is currently underwhelming and doesn't do the best job of advertising our newsletters, reflecting the quality of the product or providing a good user experience. In the process of revamping this page, we should look at using more modern technologies for developing and rendering the page.
-`frontend` as a project is moving away from rendering more generally. IT therefore makes sense for this particular page to live elsewhere and there is a benefit in bringing the page in line with other modern Guardian projects that already use React.
+
+`frontend` as a project is moving away from rendering more generally. It therefore makes sense for this particular page to live elsewhere and there is a benefit in bringing the page in line with other modern Guardian projects that already use React.
 
 ## Goals and non-Goals
 

--- a/docs/01-design-doc.md
+++ b/docs/01-design-doc.md
@@ -6,6 +6,10 @@ The [newsletters round up page][] is currently underwhelming and doesn't do the 
 
 ## Goals and non-Goals
 
+-   Improve developer experience by using the right tool for the job (a frontend technology in this case).
+-   Improve user experience by making the all newsletters roundup page easier to use.
+-   Improve the design and flow of the page to reflect the product it is advertising.
+
 ## Design
 
 ### Basic building blocks

--- a/docs/01-design-doc.md
+++ b/docs/01-design-doc.md
@@ -2,13 +2,14 @@
 
 ## Context and Scope
 
-The [newsletters round up page][] is currently underwhelming and doesn't do the best job of advertising our newsletters, reflecting the quality of the product or providing a good user experience. In the process of revamping this page, we should look at using more modern technologies for developing and rendering the page. In particular, we want to bring the page in line with other modern Guardian projects by using React.
+The [newsletters round up page][] is currently underwhelming and doesn't do the best job of advertising our newsletters, reflecting the quality of the product or providing a good user experience. In the process of revamping this page, we should look at using more modern technologies for developing and rendering the page.
+`frontend` as a project is moving away from rendering more generally. IT therefore makes sense for this particular page to live elsewhere and there is a benefit in bringing the page in line with other modern Guardian projects that already use React.
 
 ## Goals and non-Goals
 
--   Improve developer experience by using the right tool for the job (a frontend technology in this case).
 -   Improve user experience by making the all newsletters roundup page easier to use.
 -   Improve the design and flow of the page to reflect the product it is advertising.
+-   Improve developer experience by using the right tool for the job (a frontend technology in this case).
 
 ## Design
 
@@ -24,7 +25,8 @@ The [newsletters round up page][] is currently underwhelming and doesn't do the 
 What needs holding in state and where does it need to be shared?
 
 -   The selected list of newsletters needs to be shared across the page.
--   Whether an email is valid or not will need holding in state as well
+-   Whether a user is signed in and their current newsletter subscriptions.
+-   Whether an email is valid or not will need holding in state as well, only in the sign in form.
 
 <!-- URL reference links -->
 

--- a/docs/01-design-doc.md
+++ b/docs/01-design-doc.md
@@ -1,0 +1,27 @@
+# Newsletters RoundUp Page Design Document
+
+## Context and Scope
+
+The [newsletters round up page][] is currently underwhelming and doesn't do the best job of advertising our newsletters, reflecting the quality of the product or providing a good user experience. In the process of revamping this page, we should look at using more modern technologies for developing and rendering the page. In particular, we want to bring the page in line with other modern Guardian projects by using React.
+
+## Goals and non-Goals
+
+## Design
+
+### Basic building blocks
+
+-   **Cards**: The sign up cards form the basic atomic unit of the page. There will be various differnet approaches to how these are styled, but the concept of having a card per newsletter (either individually or across regions) will remain.
+-   **Sections**: We group the newsletters by section/theme. There will most likely be a filter at the top to reduce how many of these are visible at once, and there may also be an additional "Featured" section in addition to the existing ones.
+-   **Email input field**: This is currently done per card, but an improvement is to have a single input field and then newsletters can be selected using tick boxes.
+-   **Page**: The page and all of its child components. This will probably need to be the single source of truth for state.
+
+### State
+
+What needs holding in state and where does it need to be shared?
+
+-   The selected list of newsletters needs to be shared across the page.
+-   Whether an email is valid or not will need holding in state as well
+
+<!-- URL reference links -->
+
+[newsletters round up page]: https://www.theguardian.com/email-newsletters

--- a/docs/02-tech-references.md
+++ b/docs/02-tech-references.md
@@ -1,0 +1,7 @@
+# Tech References
+
+## State
+
+-   [Lifting state up in React](https://reactjs.org/docs/lifting-state-up.html)
+-   [Prop drilling](https://kentcdodds.com/blog/prop-drilling) (This is a general approach at The Guardian and worth considering)
+-   [Using React hooks](https://reactjs.org/docs/hooks-intro.html)


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->
It's important to keep track of decisions around the project and what we
want our goals to be. This prevents feature creep and makes sure that
we're focussing on the desired behaviour as a goal. The design doc is
where we outline this.

I was also getting some annoying markdownlint warnings that kept being
triggered by some default formatting VS Code wanted to implement. Rather
than trying to fix that, I've just turned off the rules that were
causing problems. I don't think for this project we need towrry about
line length in markdown or how many spaces we enforce for lists. If
people feel otherwise, they're welcome to edit this as needed.

